### PR TITLE
Workaround for compiler error that occurs since FSF GNAT 11

### DIFF
--- a/src/bullfrog-access_types-advanced_smart_access_traits.ads
+++ b/src/bullfrog-access_types-advanced_smart_access_traits.ads
@@ -60,6 +60,7 @@ private
    Placeholder : constant Dummy := (null record);
    
    function Get_Package_ID return Trait_Package_ID is 
-      (Trait_Package_ID(Placeholder'Address));
+      (Trait_Package_ID
+         (System.Storage_Elements.To_Integer (Placeholder'Address)));
    
 end Bullfrog.Access_Types.Advanced_Smart_Access_Traits;

--- a/src/bullfrog-access_types.ads
+++ b/src/bullfrog-access_types.ads
@@ -27,7 +27,7 @@
 --  covered by the GNU Public License.                                      --
 ------------------------------------------------------------------------------
 
-private with System;
+private with System.Storage_Elements;
 
 -- Base package for special access types
 package Bullfrog.Access_Types with Pure is
@@ -37,6 +37,6 @@ package Bullfrog.Access_Types with Pure is
 
 private
 
-   type Trait_Package_ID is new System.Address;
+   type Trait_Package_ID is new System.Storage_Elements.Integer_Address;
 
 end Bullfrog.Access_Types;


### PR DESCRIPTION
This uses Integer_Address instead of Address for type Trait_Package_ID to avoid compile errors in recent versions of GNAT.

Fixes #14